### PR TITLE
feat: add Service and ServiceMonitor templates for metrics support

### DIFF
--- a/charts/chart-sentinel/Chart.yaml
+++ b/charts/chart-sentinel/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.11
+version: 0.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/chart-sentinel/README.md
+++ b/charts/chart-sentinel/README.md
@@ -1,6 +1,6 @@
 # chart-sentinel
 
-![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A Helm chart for ChartSentinel
 

--- a/charts/chart-sentinel/templates/service-metrics.yaml
+++ b/charts/chart-sentinel/templates/service-metrics.yaml
@@ -1,16 +1,18 @@
+{{- if and (.Values.server.metricsPort) (ne .Values.server.metricsPort .Values.server.port) }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "chart-sentinel.fullname" . }}
+  name: {{ include "chart-sentinel.fullname" . }}-metrics
   labels:
     {{- include "chart-sentinel.labels" . | nindent 4 }}
-    component: app
+    component: metrics
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: metrics
       protocol: TCP
       name: http
   selector:
     {{- include "chart-sentinel.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/chart-sentinel/templates/servicemonitor.yaml
+++ b/charts/chart-sentinel/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.prometheus.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "chart-sentinel.fullname" . }}
+  labels:
+    {{- include "chart-sentinel.labels" . | nindent 4 }}
+    {{- if eq .Values.server.metricsPort .Values.server.port }}
+    component: app
+    {{- else }}
+    component: metrics
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "chart-sentinel.labels" . | nindent 6 }}
+      {{- if eq .Values.server.metricsPort .Values.server.port }}
+      component: app
+      {{- else }}
+      component: metrics
+      {{- end }}
+  endpoints:
+  - port: http
+    path: /metrics
+{{- end -}}

--- a/charts/chart-sentinel/values.yaml
+++ b/charts/chart-sentinel/values.yaml
@@ -42,8 +42,7 @@ podSecurityContext:
   {}
   # fsGroup: 2000
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an optional metrics Service, created only when a separate metrics port is configured.
  * Adds an optional Prometheus ServiceMonitor (config-enabled) to scrape /metrics on the http port; it targets either the app or metrics component based on port configuration.
* **Chores**
  * Adds a component label to the main Service for clearer app/metrics differentiation.
  * Bumps chart version and updates README version badge.
* **Style**
  * Minor YAML formatting cleanup for securityContext with no behavioral impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->